### PR TITLE
feat(logging): add NOTICE log level

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -50,6 +50,9 @@ const (
 	DebugLevel = slog.LevelDebug
 	// InfoLevel is the default logging priority.
 	InfoLevel = slog.LevelInfo
+	// NoticeLevel is for normal but significant events, more important than Info
+	// but not a warning. It maps to Cloud Logging's NOTICE severity.
+	NoticeLevel = slog.LevelInfo + 2
 	// WarnLevel logs are more important than Info, but don't need individual
 	// human review.
 	WarnLevel = slog.LevelWarn
@@ -158,6 +161,31 @@ func (l *Logger) With(args ...any) *Logger {
 	return &Logger{Logger: log}
 }
 
+// NoticeContext logs at [NoticeLevel] with the given context.
+//
+// Parameters:
+//
+//	ctx - the context for logging
+//	msg - the message to log
+//	args - additional arguments for the log message
+func (l *Logger) NoticeContext(
+	ctx context.Context,
+	msg string,
+	args ...any,
+) {
+	l.Log(ctx, NoticeLevel, msg, args...)
+}
+
+// Notice logs at [NoticeLevel].
+//
+// Parameters:
+//
+//	msg - the message to log
+//	args - additional arguments for the log message
+func (l *Logger) Notice(msg string, args ...any) {
+	l.NoticeContext(context.Background(), msg, args...)
+}
+
 // PanicContext logs at [PanicLevel] with the given context and then panics with the given message.
 //
 // Parameters:
@@ -236,6 +264,13 @@ func (lc *LoggerWithContext) Info(
 	args ...any,
 ) {
 	lc.l.InfoContext(lc.ctx, msg, args...)
+}
+
+func (lc *LoggerWithContext) Notice(
+	msg string,
+	args ...any,
+) {
+	lc.l.NoticeContext(lc.ctx, msg, args...)
 }
 
 func (lc *LoggerWithContext) Warn(
@@ -358,6 +393,8 @@ func replacer(groups []string, a slog.Attr) slog.Attr {
 			a.Value = slog.StringValue("DEBUG")
 		case InfoLevel:
 			a.Value = slog.StringValue("INFO")
+		case NoticeLevel:
+			a.Value = slog.StringValue("NOTICE")
 		case WarnLevel:
 			a.Value = slog.StringValue("WARNING")
 		case ErrorLevel, DPanicLevel:

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -39,3 +39,35 @@ func TestLogger(t *testing.T) {
 		t.Errorf("Expected trace ID not found or incorrect, got: %v", traceID)
 	}
 }
+
+func TestNoticeLevel(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := logging.NewLogger(&logging.LoggerConfig{
+		ProjectID:   "test-project",
+		ServiceName: "test-service",
+		MinLevel:    logging.DebugLevel,
+
+		Output: &buf,
+	})
+
+	logger.Notice("This is a notice message", logging.String("key", "value"))
+
+	var logMap map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &logMap); err != nil {
+		t.Fatalf("Failed to parse JSON log: %v", err)
+	}
+
+	if severity, ok := logMap["severity"]; !ok || severity != "NOTICE" {
+		t.Errorf("Expected severity NOTICE, got: %v", severity)
+	}
+
+	if msg, ok := logMap["message"]; !ok || msg != "This is a notice message" {
+		t.Errorf("Expected notice message, got: %v", msg)
+	}
+
+	// Notice is below Warn, so it must not include a stacktrace.
+	if _, ok := logMap["stacktrace"]; ok {
+		t.Errorf("Did not expect a stacktrace for NOTICE level")
+	}
+}


### PR DESCRIPTION
Add a NoticeLevel constant (maps to Cloud Logging NOTICE) and expose convenience methods: Logger.NoticeContext, Logger.Notice and LoggerWithContext.Notice. Update the severity replacer to emit "NOTICE". Add TestNoticeLevel to verify JSON output severity, message and that no stacktrace is emitted for NOTICE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Notice" log level positioned between informational and warning severity, enabling more granular categorization of application logs.

* **Tests**
  * Added test coverage to validate the new log level's correct behavior and output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->